### PR TITLE
Change default logging level

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,6 @@ ds:
     max_facts: "-1"
     mock: "False"
     only_login: "False"
+logging:
+  level:
+    root: error


### PR DESCRIPTION
The services crashes servers due to the amount of logs it generates.